### PR TITLE
Fix contract update hook

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -486,8 +486,10 @@ function plugin_projectbridge_contract_add(Contract $contract, $force = false)
  * @return void
  */
 function plugin_projectbridge_ticket_update(Ticket $ticket)
-{
-    if (!empty($ticket->input['update']) && $ticket->input['update'] == 'Faire la liaison' && !empty($ticket->input['projectbridge_project_id'])) {
+{    
+    $update_val = $contract->input['update'] ?? $contract->input['_update'] ?? null;
+
+    if ($update_val == __('Make the connection', 'projectbridge') && !empty($ticket->input['projectbridge_project_id'])) {
         $is_project_link_update = true;
         $contract_id = null;
     } else {

--- a/hook.php
+++ b/hook.php
@@ -287,7 +287,7 @@ function plugin_projectbridge_pre_contract_update(Contract $contract)
     $update_val = $contract->input['update'] ?? $contract->input['_update'] ?? null;
 
     if ($contract->canUpdate() && $update_val !== null && isset($contract->input['projectbridge_project_id'])) {
-        if ($update_val != __('Lier les tickets au renouvellement', 'projectbridge')) {
+        if ($update_val != __('Link tickets to renewal', 'projectbridge')) {
             // update contract
             $nb_hours = 0;
 

--- a/hook.php
+++ b/hook.php
@@ -283,9 +283,11 @@ function plugin_projectbridge_pre_entity_update(Entity $entity, $force = false)
 function plugin_projectbridge_pre_contract_update(Contract $contract)
 {
     global $DB;
+    
+    $update_val = $contract->input['update'] ?? $contract->input['_update'] ?? null;
 
-    if ($contract->canUpdate() && isset($contract->input['update']) && isset($contract->input['projectbridge_project_id'])) {
-        if ($contract->input['update'] != 'Lier les tickets au renouvellement') {
+    if ($contract->canUpdate() && $update_val !== null && isset($contract->input['projectbridge_project_id'])) {
+        if ($update_val != __('Lier les tickets au renouvellement', 'projectbridge')) {
             // update contract
             $nb_hours = 0;
 


### PR DESCRIPTION
1. Check in hook was only correct in French.

2. Check should be done on `$input['update']`, fallbacking to `$input['_update']`, to handle transition thay will probably be introduced by https://github.com/glpi-project/glpi/pull/10857.